### PR TITLE
Allow user to change recording output location

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,10 @@ If SwiftData is configured to use CloudKit:
 - Add code comments and documentation comments as needed.
 - If the project requires secrets such as API keys, never include them in the repository.
 
+## Git workflow
+
+- When working on a GitHub issue, use `gh issue develop <issue-number> --checkout` to create and checkout a branch with consistent naming.
+
 ## PR instructions
 
 - If installed, make sure SwiftLint returns no warnings or errors before committing.


### PR DESCRIPTION
## Summary
- Add custom output directory selection via NSOpenPanel in Settings > Content tab
- Persist user-selected directories using security-scoped bookmarks for sandbox compatibility
- Display current output path with "Change..." button and "Reset" option when custom directory is set
- Add helper methods for security-scoped resource access during recording

Closes #2