### PR TITLE
feat(menu-bar): add open output folder button

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,11 @@ If SwiftData is configured to use CloudKit:
 ## Git workflow
 
 - When working on a GitHub issue, use `gh issue develop <issue-number> --checkout` to create and checkout a branch with consistent naming.
+- Use conventional commit format for all commits: `type(scope): subject`
+  - Types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`
+  - Example: `feat(menu-bar): add open output folder button`
+  - Keep subject line under 50 characters when possible
+  - Use present tense ("add" not "added")
 
 ## PR instructions
 

--- a/BetterCapture/View/MenuBarView.swift
+++ b/BetterCapture/View/MenuBarView.swift
@@ -71,6 +71,17 @@ struct MenuBarView: View {
             MenuBarDivider()
 
             // Bottom Actions
+            MenuBarActionButton(title: "Open Output Folder", systemImage: "folder") {
+                let settings = viewModel.settings
+                let didStart = settings.startAccessingOutputDirectory()
+                defer {
+                    if didStart {
+                        settings.stopAccessingOutputDirectory()
+                    }
+                }
+                NSWorkspace.shared.selectFile(nil, inFileViewerRootedAtPath: settings.outputDirectory.path)
+            }
+
             MenuBarActionButton(title: "Settings...", systemImage: "gear") {
                 openSettings()
             }


### PR DESCRIPTION
Add a new button to the menu bar interface that opens the output directory in Finder. Properly handles security-scoped resource access for custom output directories.

Also update AGENTS.md to document conventional commit format requirements.