### PR TITLE
fix(menu-bar): activate app before opening settings

### DIFF
--- a/BetterCapture/View/MenuBarView.swift
+++ b/BetterCapture/View/MenuBarView.swift
@@ -96,6 +96,7 @@ struct MenuBarView: View {
             }
 
             MenuBarActionButton(title: "Settings...", systemImage: "gear") {
+                NSApplication.shared.activate(ignoringOtherApps: true)
                 openSettings()
             }
 


### PR DESCRIPTION
Ensures Settings window appears in foreground when opened from menu bar by calling NSApplication.shared.activate(ignoringOtherApps: true) before openSettings().

Fixes #5