### PR TITLE
feat: add support for HDR when using proRes422/4444

### DIFF
--- a/BetterCapture/Model/SettingsStore.swift
+++ b/BetterCapture/Model/SettingsStore.swift
@@ -46,6 +46,16 @@ enum VideoCodec: String, CaseIterable, Identifiable {
             return false
         }
     }
+
+    /// Whether this codec supports HDR (10-bit) recording
+    var supportsHDR: Bool {
+        switch self {
+        case .proRes422, .proRes4444:
+            return true
+        case .h264, .hevc:
+            return false
+        }
+    }
 }
 
 /// Container format for output files
@@ -116,6 +126,11 @@ final class SettingsStore {
                 captureAlphaChannel = false
             }
             // HEVC can toggle alpha, so leave it as-is
+
+            // Disable HDR for codecs that don't support it
+            if !newValue.supportsHDR {
+                captureHDR = false
+            }
         }
     }
 
@@ -136,6 +151,18 @@ final class SettingsStore {
         set {
             withMutation(keyPath: \.captureAlphaChannel) {
                 UserDefaults.standard.set(newValue, forKey: "captureAlphaChannel")
+            }
+        }
+    }
+
+    var captureHDR: Bool {
+        get {
+            access(keyPath: \.captureHDR)
+            return UserDefaults.standard.bool(forKey: "captureHDR")
+        }
+        set {
+            withMutation(keyPath: \.captureHDR) {
+                UserDefaults.standard.set(newValue, forKey: "captureHDR")
             }
         }
     }

--- a/BetterCapture/Service/CaptureEngine.swift
+++ b/BetterCapture/Service/CaptureEngine.swift
@@ -210,8 +210,16 @@ final class CaptureEngine: NSObject {
             config.microphoneCaptureDeviceID = microphoneID
         }
 
-        // Pixel format - use BGRA for compatibility with AVAssetWriter
-        config.pixelFormat = kCVPixelFormatType_32BGRA
+        // Configure pixel format and dynamic range based on HDR setting
+        if settings.captureHDR && settings.videoCodec.supportsHDR {
+            // HDR: Use 10-bit YCbCr format with HDR dynamic range
+            config.pixelFormat = kCVPixelFormatType_420YpCbCr10BiPlanarVideoRange
+            config.captureDynamicRange = .hdrLocalDisplay
+        } else {
+            // SDR: Use 8-bit BGRA format
+            config.pixelFormat = kCVPixelFormatType_32BGRA
+            config.captureDynamicRange = .SDR
+        }
 
         return config
     }

--- a/BetterCapture/View/MenuBarSettingsView.swift
+++ b/BetterCapture/View/MenuBarSettingsView.swift
@@ -430,6 +430,13 @@ struct VideoSettingsSection: View {
                 isOn: $settings.captureAlphaChannel,
                 isDisabled: !settings.videoCodec.canToggleAlpha
             )
+
+            // HDR Recording Toggle (disabled for codecs that don't support HDR)
+            MenuBarToggle(
+                name: "HDR Recording",
+                isOn: $settings.captureHDR,
+                isDisabled: !settings.videoCodec.supportsHDR
+            )
         }
     }
 }

--- a/BetterCapture/View/SettingsView.swift
+++ b/BetterCapture/View/SettingsView.swift
@@ -50,6 +50,14 @@ struct VideoSettingsView: View {
         }
     }
 
+    private var hdrHelpText: String {
+        if settings.videoCodec.supportsHDR {
+            return "Enable 10-bit HDR capture for high dynamic range content"
+        } else {
+            return "HDR is only supported with ProRes 422 and ProRes 4444 codecs"
+        }
+    }
+
     var body: some View {
         Form {
             Section("Recording") {
@@ -76,6 +84,10 @@ struct VideoSettingsView: View {
                 Toggle("Capture Alpha Channel", isOn: $settings.captureAlphaChannel)
                     .disabled(!settings.videoCodec.canToggleAlpha)
                     .help(alphaChannelHelpText)
+
+                Toggle("HDR Recording", isOn: $settings.captureHDR)
+                    .disabled(!settings.videoCodec.supportsHDR)
+                    .help(hdrHelpText)
             }
         }
         .formStyle(.grouped)


### PR DESCRIPTION
Allows to capture content using HDR. This is not
supported for all encodings. While it's technically possible for h265, I decided against it for now.
The main reason is that we would have to change
some settings for h265 depending on whether we
enabled hdr or not.

Important: proRes422/444 + HDR requires lots of memory and might impact overall performance.