### PR TITLE
fix: fail builds on error

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -80,6 +80,7 @@ jobs:
 
       - name: Build application
         run: |
+          set -o pipefail
           xcodebuild archive \
             -project "${{ env.APP_NAME }}.xcodeproj" \
             -scheme "${{ env.SCHEME }}" \
@@ -90,7 +91,7 @@ jobs:
             CODE_SIGN_IDENTITY="Developer ID Application" \
             CODE_SIGN_STYLE=Manual \
             OTHER_CODE_SIGN_FLAGS="--timestamp --options=runtime" \
-            | xcbeautify --renderer github-actions || true
+            | xcbeautify --renderer github-actions
 
       - name: Export application
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,7 @@ jobs:
   build:
     runs-on: macos-15
     timeout-minutes: 30
+    if: github.event_name == 'workflow_dispatch' || github.event.release.prerelease != true
 
     steps:
       - name: Checkout repository
@@ -81,6 +82,7 @@ jobs:
 
       - name: Build application
         run: |
+          set -o pipefail
           xcodebuild archive \
             -project "${{ env.APP_NAME }}.xcodeproj" \
             -scheme "${{ env.SCHEME }}" \
@@ -91,7 +93,7 @@ jobs:
             CODE_SIGN_IDENTITY="Developer ID Application" \
             CODE_SIGN_STYLE=Manual \
             OTHER_CODE_SIGN_FLAGS="--timestamp --options=runtime" \
-            | xcbeautify --renderer github-actions || true
+            | xcbeautify --renderer github-actions
 
       - name: Export application
         run: |


### PR DESCRIPTION
We now also prevent the release workflow
from running when it's a pre-release.