### PR TITLE
ci: add path filter for deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,8 @@ on:
   # Using a different branch name? Replace `main` with your branch’s name
   push:
     branches: [main]
+    paths:
+      - 'website/'
   # Allows you to run this workflow manually from the Actions tab on GitHub.
   workflow_dispatch:
 


### PR DESCRIPTION
Specify paths for deployment workflow to trigger only on changes in the 'website/' directory.