### PR TITLE
fix(settings): show correct version and website link

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -73,10 +73,9 @@ jobs:
       - name: Update version in project
         run: |
           VERSION=${{ steps.version.outputs.version }}
-          # Extract major.minor for MARKETING_VERSION (strip pre-release suffix)
-          MARKETING_VERSION=$(echo "$VERSION" | grep -oE '^[0-9]+\.[0-9]+')
-          agvtool new-marketing-version "$MARKETING_VERSION"
-          agvtool new-version -all 1
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          agvtool new-marketing-version "$VERSION"
+          agvtool new-version -all "$SHORT_SHA"
 
       - name: Build application
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,11 +83,9 @@ jobs:
       - name: Update version in project
         run: |
           VERSION=${{ steps.version.outputs.version }}
-          # Extract major.minor for MARKETING_VERSION
-          MARKETING_VERSION=$(echo "$VERSION" | grep -oE '^[0-9]+\.[0-9]+')
-          # Use full version for display if it has patch
-          agvtool new-marketing-version "$MARKETING_VERSION"
-          agvtool new-version -all 1
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          agvtool new-marketing-version "$VERSION"
+          agvtool new-version -all "$SHORT_SHA"
 
       - name: Set Sparkle public key in Info.plist
         env:

--- a/BetterCapture/View/SettingsView.swift
+++ b/BetterCapture/View/SettingsView.swift
@@ -258,7 +258,7 @@ struct AboutSection: View {
             LabeledContent("Version", value: "\(appVersion) (\(buildNumber))")
 
             LabeledContent("Website") {
-                Link("bettercapture.app", destination: URL(string: "https://bettercapture.app")!)
+                Link("jsattler.github.io/BetterCapture", destination: URL(string: "https://jsattler.github.io/BetterCapture")!)
             }
 
             LabeledContent("Source Code") {


### PR DESCRIPTION
## Summary
- Update website link from placeholder to https://jsattler.github.io/BetterCapture
- Use full release version for `MARKETING_VERSION` instead of extracting only major.minor
- Use short git SHA as build number to show version like `1.0.0 (abc1234)`

Closes #46