### PR TITLE
fix(build): use calendar versioning for Sparkle update comparison

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -70,12 +70,21 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Building pre-release version: $VERSION"
 
-      - name: Update version in project
+      - name: Determine build identifiers
+        id: build
         run: |
           VERSION=${{ steps.version.outputs.version }}
           SHORT_SHA=$(git rev-parse --short HEAD)
-          agvtool new-marketing-version "$VERSION"
-          agvtool new-version -all "$SHORT_SHA"
+          echo "marketing_version=$VERSION" >> $GITHUB_OUTPUT
+          echo "build_number=$VERSION" >> $GITHUB_OUTPUT
+          echo "git_sha=$SHORT_SHA" >> $GITHUB_OUTPUT
+          echo "Marketing version: $VERSION"
+          echo "Build number: $VERSION"
+          echo "Git SHA: $SHORT_SHA"
+
+      - name: Set git SHA in Info.plist
+        run: |
+          /usr/libexec/PlistBuddy -c "Add :GitSHA string ${{ steps.build.outputs.git_sha }}" "BetterCapture/Info.plist"
 
       - name: Build application
         run: |
@@ -90,6 +99,8 @@ jobs:
             CODE_SIGN_IDENTITY="Developer ID Application" \
             CODE_SIGN_STYLE=Manual \
             OTHER_CODE_SIGN_FLAGS="--timestamp --options=runtime" \
+            MARKETING_VERSION="${{ steps.build.outputs.marketing_version }}" \
+            CURRENT_PROJECT_VERSION="${{ steps.build.outputs.build_number }}" \
             | xcbeautify --renderer github-actions
 
       - name: Export application

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,18 +80,24 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Building version: $VERSION"
 
-      - name: Update version in project
+      - name: Determine build identifiers
+        id: build
         run: |
           VERSION=${{ steps.version.outputs.version }}
           SHORT_SHA=$(git rev-parse --short HEAD)
-          agvtool new-marketing-version "$VERSION"
-          agvtool new-version -all "$SHORT_SHA"
+          echo "marketing_version=$VERSION" >> $GITHUB_OUTPUT
+          echo "build_number=$VERSION" >> $GITHUB_OUTPUT
+          echo "git_sha=$SHORT_SHA" >> $GITHUB_OUTPUT
+          echo "Marketing version: $VERSION"
+          echo "Build number: $VERSION"
+          echo "Git SHA: $SHORT_SHA"
 
-      - name: Set Sparkle public key in Info.plist
+      - name: Set Sparkle public key and git SHA in Info.plist
         env:
           SPARKLE_PUBLIC_KEY: ${{ secrets.SPARKLE_PUBLIC_EDDSA_KEY }}
         run: |
           /usr/libexec/PlistBuddy -c "Set :SUPublicEDKey $SPARKLE_PUBLIC_KEY" "BetterCapture/Info.plist"
+          /usr/libexec/PlistBuddy -c "Add :GitSHA string ${{ steps.build.outputs.git_sha }}" "BetterCapture/Info.plist"
 
       - name: Build application
         run: |
@@ -106,6 +112,8 @@ jobs:
             CODE_SIGN_IDENTITY="Developer ID Application" \
             CODE_SIGN_STYLE=Manual \
             OTHER_CODE_SIGN_FLAGS="--timestamp --options=runtime" \
+            MARKETING_VERSION="${{ steps.build.outputs.marketing_version }}" \
+            CURRENT_PROJECT_VERSION="${{ steps.build.outputs.build_number }}" \
             | xcbeautify --renderer github-actions
 
       - name: Export application
@@ -226,8 +234,10 @@ jobs:
             || echo "No previous appcast found, will create a fresh one"
 
           # Run the appcast generation script
+          # Note: BUILD_NUMBER uses VERSION for Sparkle comparison (not git SHA)
           cd "$APPCAST_DIR"
           VERSION="$VERSION" \
+          BUILD_NUMBER="$VERSION" \
           DMG_URL="$DMG_URL" \
           RELEASE_NOTES="$RELEASE_NOTES" \
           RELEASE_URL="$RELEASE_URL" \

--- a/BetterCapture/View/SettingsView.swift
+++ b/BetterCapture/View/SettingsView.swift
@@ -249,13 +249,13 @@ struct AboutSection: View {
         Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "Unknown"
     }
 
-    private var buildNumber: String {
-        Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "Unknown"
+    private var gitSHA: String {
+        Bundle.main.infoDictionary?["GitSHA"] as? String ?? "dev"
     }
 
     var body: some View {
         Section("About") {
-            LabeledContent("Version", value: "\(appVersion) (\(buildNumber))")
+            LabeledContent("Version", value: "v\(appVersion) (\(gitSHA))")
 
             LabeledContent("Website") {
                 Link("jsattler.github.io/BetterCapture", destination: URL(string: "https://jsattler.github.io/BetterCapture")!)

--- a/dist/update_appcast.py
+++ b/dist/update_appcast.py
@@ -16,6 +16,7 @@ Expected files in the current directory:
 
 Required environment variables:
     - VERSION            The version number (e.g. 1.0.0).
+    - BUILD_NUMBER       The build number (typically same as VERSION).
     - DMG_URL            The download URL for the DMG.
 
 Optional environment variables:
@@ -33,6 +34,7 @@ from datetime import datetime, timezone
 
 now = datetime.now(timezone.utc)
 version = os.environ["VERSION"]
+build_number = os.environ["BUILD_NUMBER"]
 dmg_url = os.environ["DMG_URL"]
 release_notes = os.environ.get("RELEASE_NOTES", "")
 release_url = os.environ.get("RELEASE_URL", "")
@@ -208,9 +210,8 @@ elem = ET.SubElement(item, "pubDate")
 elem.text = now.strftime(pubdate_format)
 
 elem = ET.SubElement(item, f"{{{SPARKLE_NS}}}version")
-# Use a build number derived from version for CFBundleVersion comparison
 # Sparkle compares sparkle:version against CFBundleVersion
-elem.text = "1"  # Will be overridden in CI with the actual build number
+elem.text = build_number
 
 elem = ET.SubElement(item, f"{{{SPARKLE_NS}}}shortVersionString")
 elem.text = version


### PR DESCRIPTION
## Summary

Fixes the version display issue where the app showed `1.0 (1607da0)` instead of the correct version.

### Problem

1. `agvtool` commands weren't working because the project lacks `VERSIONING_SYSTEM = apple-generic`
2. Git SHAs were being used for `CFBundleVersion`, but Sparkle requires incrementing/comparable version numbers for update comparison
3. The appcast had `sparkle:version` hardcoded to `"1"`

### Solution

- Pass `MARKETING_VERSION` and `CURRENT_PROJECT_VERSION` directly to `xcodebuild` instead of using `agvtool`
- Use the semantic version (e.g., `2026.1.1`) for both `CFBundleShortVersionString` and `CFBundleVersion`
- Add a custom `GitSHA` key to Info.plist for commit identification in the UI
- Update `SettingsView` to display `v2026.1.1 (abc123f)` format
- Pass `BUILD_NUMBER` to `update_appcast.py` for proper `sparkle:version` value

### Result

| Component | Value |
|-----------|-------|
| Settings display | `v2026.1.1 (abc123f)` |
| `CFBundleShortVersionString` | `2026.1.1` |
| `CFBundleVersion` | `2026.1.1` |
| `sparkle:version` | `2026.1.1` |

Sparkle will now correctly compare semantic versions (e.g., `2026.1.1` vs `2026.1.2`) to determine if updates are available.