### PR TITLE
fix(recording): save recording when captured window closes

### DIFF
--- a/BetterCapture/ViewModel/RecorderViewModel.swift
+++ b/BetterCapture/ViewModel/RecorderViewModel.swift
@@ -282,11 +282,11 @@ extension RecorderViewModel: CaptureEngineDelegate {
                     await stopRecording()
                 }
             } else {
-                // Unexpected error - cancel the recording
-                stopTimer()
-                assetWriter.cancel()
-                state = .idle
-                notificationService.sendRecordingStoppedNotification(error: error)
+                // Stream error during recording - try to save what we have
+                logger.warning("Stream stopped unexpectedly, attempting to save recording...")
+                Task {
+                    await stopRecording()
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- When recording a window that gets closed, the app now attempts to save the recording instead of discarding it
- Previously, any non-`.userStopped` stream error during recording would call `assetWriter.cancel()`, losing all captured data
- Now both code paths (user stop sharing + unexpected stream stop) call `stopRecording()`, which finalizes the file gracefully and falls back to cancel if finalization fails

## Test plan
- [x] Start recording a specific window
- [x] Close that window while recording is active
- [x] Verify the recording is saved to the output folder
- [x] Verify the saved file is playable in QuickTime