### PR TITLE
fix: call `startAccessingOutputDirectory` before opening output folder

### DIFF
--- a/BetterCapture/Service/NotificationService.swift
+++ b/BetterCapture/Service/NotificationService.swift
@@ -29,6 +29,7 @@ final class NotificationService: NSObject {
 
     // MARK: - Properties
 
+    private let settings: SettingsStore
     private let logger = Logger(
         subsystem: Bundle.main.bundleIdentifier ?? "BetterCapture",
         category: "NotificationService"
@@ -36,7 +37,8 @@ final class NotificationService: NSObject {
 
     // MARK: - Initialization
 
-    override init() {
+    init(settings: SettingsStore) {
+        self.settings = settings
         super.init()
         setupNotificationDelegate()
         registerNotificationCategories()
@@ -183,6 +185,8 @@ final class NotificationService: NSObject {
     // MARK: - Private Methods
 
     private func openFolderInFinder(path: String) {
+        _ = settings.startAccessingOutputDirectory()
+        defer { settings.stopAccessingOutputDirectory() }
         let url = URL(filePath: path)
         NSWorkspace.shared.open(url)
     }

--- a/BetterCapture/ViewModel/RecorderViewModel.swift
+++ b/BetterCapture/ViewModel/RecorderViewModel.swift
@@ -97,7 +97,7 @@ final class RecorderViewModel {
         self.audioDeviceService = AudioDeviceService()
         self.cameraDeviceService = CameraDeviceService()
         self.previewService = PreviewService()
-        self.notificationService = NotificationService()
+        self.notificationService = NotificationService(settings: settings)
         self.permissionService = PermissionService()
         self.captureEngine = CaptureEngine()
         self.assetWriter = AssetWriter()


### PR DESCRIPTION
Before this fix opening a custom output folder
would fail because we did not make the call to
`startAccessingOutputDirectory`. This should fix
any permission issues.