### PR TITLE
chore(deps): upgrade Sparkle to 2.9.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ env:
   APP_NAME: BetterCapture
   SCHEME: BetterCapture
   XCODE_VERSION: "26.0"
-  SPARKLE_VERSION: "2.7.3"
+  SPARKLE_VERSION: "2.9.0"
 
 jobs:
   build:

--- a/BetterCapture.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/BetterCapture.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sparkle-project/Sparkle",
       "state" : {
-        "revision" : "5581748cef2bae787496fe6d61139aebe0a451f6",
-        "version" : "2.8.1"
+        "revision" : "21d8df80440b1ca3b65fa82e40782f1e5a9e6ba2",
+        "version" : "2.9.0"
       }
     }
   ],


### PR DESCRIPTION
## Summary

- Updates `Package.resolved` to pin Sparkle to 2.9.0 (from 2.8.1)
- Updates `SPARKLE_VERSION` in `release.yml` to 2.9.0 (from 2.7.3) to keep CI tooling in sync with the resolved library version

Closes #126