### PR TITLE
Add window resize presets for selected windows

### DIFF
--- a/BetterCapture/Model/WindowResizePreset.swift
+++ b/BetterCapture/Model/WindowResizePreset.swift
@@ -1,0 +1,130 @@
+//
+//  WindowResizePreset.swift
+//  BetterCapture
+//
+//  Created by Karel Busta on 13.05.26.
+//
+
+import CoreGraphics
+
+/// Common target sizes for preparing a selected window before recording.
+enum WindowResizePreset: String, CaseIterable, Identifiable {
+    case portrait720
+    case portrait1080
+    case landscape720
+    case landscape1080
+    case square1080
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .portrait720:
+            "9:16 720x1280"
+        case .portrait1080:
+            "9:16 1080x1920"
+        case .landscape720:
+            "16:9 1280x720"
+        case .landscape1080:
+            "16:9 1920x1080"
+        case .square1080:
+            "1:1 1080x1080"
+        }
+    }
+
+    var size: CGSize {
+        switch self {
+        case .portrait720:
+            CGSize(width: 720, height: 1280)
+        case .portrait1080:
+            CGSize(width: 1080, height: 1920)
+        case .landscape720:
+            CGSize(width: 1280, height: 720)
+        case .landscape1080:
+            CGSize(width: 1920, height: 1080)
+        case .square1080:
+            CGSize(width: 1080, height: 1080)
+        }
+    }
+}
+
+/// Pure frame calculation for fitting resize presets onto the visible screen.
+enum WindowResizeLayout {
+    static let defaultMargin: CGFloat = 24
+
+    private static let minimumDimension: CGFloat = 160
+
+    static func targetFrame(
+        for preset: WindowResizePreset,
+        currentFrame: CGRect,
+        visibleFrame: CGRect,
+        margin: CGFloat = defaultMargin
+    ) -> CGRect {
+        let bounds = clampedBounds(from: visibleFrame, margin: margin)
+        guard bounds.width > 0, bounds.height > 0 else { return .zero }
+
+        let targetSize = preset.size.fittingWithin(bounds.size)
+        return frame(centeredOn: currentFrame.center, size: targetSize, clampedTo: bounds)
+    }
+
+    private static func clampedBounds(from visibleFrame: CGRect, margin: CGFloat) -> CGRect {
+        guard visibleFrame.width > 0, visibleFrame.height > 0 else { return .zero }
+
+        let safeMargin = max(0, margin)
+        let horizontalInset = min(safeMargin, max(0, (visibleFrame.width - minimumDimension) / 2))
+        let verticalInset = min(safeMargin, max(0, (visibleFrame.height - minimumDimension) / 2))
+
+        return visibleFrame.insetBy(dx: horizontalInset, dy: verticalInset)
+    }
+
+    private static func frame(centeredOn center: CGPoint, size: CGSize, clampedTo bounds: CGRect) -> CGRect {
+        let width = min(size.width, bounds.width).rounded(.down)
+        let height = min(size.height, bounds.height).rounded(.down)
+
+        let originX: CGFloat
+        if bounds.width <= width {
+            originX = bounds.minX
+        } else {
+            originX = min(max(center.x - width / 2, bounds.minX), bounds.maxX - width)
+        }
+
+        let originY: CGFloat
+        if bounds.height <= height {
+            originY = bounds.minY
+        } else {
+            originY = min(max(center.y - height / 2, bounds.minY), bounds.maxY - height)
+        }
+
+        return CGRect(
+            x: originX.rounded(),
+            y: originY.rounded(),
+            width: width,
+            height: height
+        )
+    }
+}
+
+private extension CGRect {
+    var center: CGPoint {
+        CGPoint(x: midX, y: midY)
+    }
+}
+
+private extension CGSize {
+    func fittingWithin(_ bounds: CGSize) -> CGSize {
+        if width <= bounds.width, height <= bounds.height {
+            return self
+        }
+
+        return fittingAspect(in: bounds)
+    }
+
+    private func fittingAspect(in bounds: CGSize) -> CGSize {
+        guard width > 0, height > 0, bounds.width > 0, bounds.height > 0 else {
+            return .zero
+        }
+
+        let scale = min(bounds.width / width, bounds.height / height)
+        return CGSize(width: width * scale, height: height * scale)
+    }
+}

--- a/BetterCapture/Service/WindowResizeService.swift
+++ b/BetterCapture/Service/WindowResizeService.swift
@@ -1,0 +1,267 @@
+//
+//  WindowResizeService.swift
+//  BetterCapture
+//
+//  Created by Karel Busta on 13.05.26.
+//
+
+import AppKit
+@preconcurrency import ApplicationServices
+import CoreGraphics
+import Foundation
+import ScreenCaptureKit
+
+enum WindowResizeError: LocalizedError {
+    case accessibilityPermissionMissing
+    case windowUnavailable
+    case resizeUnsupported
+    case operationFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .accessibilityPermissionMissing:
+            "Allow Accessibility access for BetterCapture, then try resizing again."
+        case .windowUnavailable:
+            "That window is no longer available for resizing."
+        case .resizeUnsupported:
+            "That window does not allow resizing."
+        case .operationFailed(let message):
+            message
+        }
+    }
+}
+
+@MainActor
+struct WindowResizeService {
+    func resize(_ window: SCWindow, to preset: WindowResizePreset) throws -> CGRect {
+        guard isAccessibilityTrusted(prompt: true) else {
+            throw WindowResizeError.accessibilityPermissionMissing
+        }
+
+        guard let target = WindowResizeTarget(window: window),
+              let accessibilityWindow = matchingAccessibilityWindow(for: target) else {
+            throw WindowResizeError.windowUnavailable
+        }
+
+        guard accessibilityWindow.isResizable else {
+            throw WindowResizeError.resizeUnsupported
+        }
+
+        let visibleFrame = visibleFrame(containing: target.frame)
+        let targetFrame = WindowResizeLayout.targetFrame(
+            for: preset,
+            currentFrame: target.frame,
+            visibleFrame: visibleFrame
+        )
+
+        try accessibilityWindow.setFrame(targetFrame)
+        return accessibilityWindow.frame ?? targetFrame
+    }
+
+    private func isAccessibilityTrusted(prompt: Bool = false) -> Bool {
+        let options = [kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String: prompt] as CFDictionary
+        return AXIsProcessTrustedWithOptions(options)
+    }
+
+    private func matchingAccessibilityWindow(for target: WindowResizeTarget) -> AccessibilityWindow? {
+        let application = AXUIElementCreateApplication(target.processID)
+        var rawWindows: CFTypeRef?
+
+        guard AXUIElementCopyAttributeValue(application, kAXWindowsAttribute as CFString, &rawWindows) == .success,
+              let windows = rawWindows as? [AXUIElement],
+              !windows.isEmpty else {
+            return nil
+        }
+
+        return windows
+            .compactMap { AccessibilityWindow(element: $0) }
+            .min { first, second in
+                matchScore(first, target: target) < matchScore(second, target: target)
+            }
+    }
+
+    private func matchScore(_ candidate: AccessibilityWindow, target: WindowResizeTarget) -> CGFloat {
+        guard let candidateFrame = candidate.frame else { return .greatestFiniteMagnitude }
+
+        let centerDistance = candidateFrame.center.distance(to: target.frame.center)
+        let sizeDelta = abs(candidateFrame.width - target.frame.width)
+            + abs(candidateFrame.height - target.frame.height)
+        let titlePenalty: CGFloat
+
+        if target.title.isEmpty || candidate.title.isEmpty || candidate.title == target.title {
+            titlePenalty = 0
+        } else {
+            titlePenalty = 220
+        }
+
+        return centerDistance + sizeDelta * 0.5 + titlePenalty
+    }
+
+    private func visibleFrame(containing frame: CGRect) -> CGRect {
+        guard let screen = screen(containing: frame) ?? NSScreen.main else {
+            return frame
+        }
+
+        return quartzVisibleFrame(for: screen)
+    }
+
+    private func screen(containing frame: CGRect) -> NSScreen? {
+        NSScreen.screens.max { first, second in
+            first.quartzFrame.intersectionArea(with: frame) < second.quartzFrame.intersectionArea(with: frame)
+        }
+    }
+
+    private func quartzVisibleFrame(for screen: NSScreen) -> CGRect {
+        let desktopFrame = NSScreen.screens.reduce(CGRect.null) { partialResult, screen in
+            partialResult.union(screen.frame)
+        }
+        let visibleFrame = screen.visibleFrame
+
+        return CGRect(
+            x: visibleFrame.minX,
+            y: desktopFrame.maxY - visibleFrame.maxY,
+            width: visibleFrame.width,
+            height: visibleFrame.height
+        )
+    }
+}
+
+private struct WindowResizeTarget {
+    let title: String
+    let processID: pid_t
+    let frame: CGRect
+
+    init?(window: SCWindow) {
+        guard let processID = window.owningApplication?.processID else {
+            return nil
+        }
+
+        self.title = window.title ?? ""
+        self.processID = processID
+        self.frame = window.frame.integral
+    }
+}
+
+private struct AccessibilityWindow {
+    let element: AXUIElement
+
+    var title: String {
+        stringValue(for: kAXTitleAttribute) ?? ""
+    }
+
+    var frame: CGRect? {
+        guard let position, let size else { return nil }
+        return CGRect(origin: position, size: size).integral
+    }
+
+    var isResizable: Bool {
+        isAttributeSettable(kAXSizeAttribute)
+    }
+
+    func setFrame(_ frame: CGRect) throws {
+        try setSize(frame.size)
+        try setPosition(frame.origin)
+    }
+
+    private var position: CGPoint? {
+        pointValue(for: kAXPositionAttribute)
+    }
+
+    private var size: CGSize? {
+        sizeValue(for: kAXSizeAttribute)
+    }
+
+    private func isAttributeSettable(_ attribute: String) -> Bool {
+        var settable = DarwinBoolean(false)
+        return AXUIElementIsAttributeSettable(element, attribute as CFString, &settable) == .success
+            && settable.boolValue
+    }
+
+    private func setPosition(_ position: CGPoint) throws {
+        var mutablePosition = position
+        guard let value = AXValueCreate(.cgPoint, &mutablePosition),
+              AXUIElementSetAttributeValue(element, kAXPositionAttribute as CFString, value) == .success else {
+            throw WindowResizeError.operationFailed("Could not move that window.")
+        }
+    }
+
+    private func setSize(_ size: CGSize) throws {
+        var mutableSize = size
+        guard let value = AXValueCreate(.cgSize, &mutableSize),
+              AXUIElementSetAttributeValue(element, kAXSizeAttribute as CFString, value) == .success else {
+            throw WindowResizeError.operationFailed("Could not resize that window.")
+        }
+    }
+
+    private func stringValue(for attribute: String) -> String? {
+        var rawValue: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, attribute as CFString, &rawValue) == .success else {
+            return nil
+        }
+
+        return rawValue as? String
+    }
+
+    private func pointValue(for attribute: String) -> CGPoint? {
+        var rawValue: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, attribute as CFString, &rawValue) == .success,
+              let rawValue,
+              CFGetTypeID(rawValue) == AXValueGetTypeID() else {
+            return nil
+        }
+
+        // swiftlint:disable:next force_cast
+        let value = rawValue as! AXValue
+        var point = CGPoint.zero
+        guard AXValueGetValue(value, .cgPoint, &point) else { return nil }
+        return point
+    }
+
+    private func sizeValue(for attribute: String) -> CGSize? {
+        var rawValue: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, attribute as CFString, &rawValue) == .success,
+              let rawValue,
+              CFGetTypeID(rawValue) == AXValueGetTypeID() else {
+            return nil
+        }
+
+        // swiftlint:disable:next force_cast
+        let value = rawValue as! AXValue
+        var size = CGSize.zero
+        guard AXValueGetValue(value, .cgSize, &size) else { return nil }
+        return size
+    }
+}
+
+private extension NSScreen {
+    var quartzFrame: CGRect {
+        let desktopFrame = NSScreen.screens.reduce(CGRect.null) { partialResult, screen in
+            partialResult.union(screen.frame)
+        }
+
+        return CGRect(
+            x: frame.minX,
+            y: desktopFrame.maxY - frame.maxY,
+            width: frame.width,
+            height: frame.height
+        )
+    }
+}
+
+private extension CGRect {
+    var center: CGPoint {
+        CGPoint(x: midX, y: midY)
+    }
+
+    func intersectionArea(with rect: CGRect) -> CGFloat {
+        let intersection = intersection(rect)
+        guard !intersection.isNull else { return 0 }
+        return intersection.width * intersection.height
+    }
+}
+
+private extension CGPoint {
+    func distance(to point: CGPoint) -> CGFloat {
+        hypot(x - point.x, y - point.y)
+    }
+}

--- a/BetterCapture/View/MenuBarView.swift
+++ b/BetterCapture/View/MenuBarView.swift
@@ -61,6 +61,17 @@ struct MenuBarView: View {
             ContentSelectionButton(viewModel: viewModel) { dismiss() }
                 .disabled(isRecording)
 
+            if viewModel.canResizeSelectedWindow {
+                WindowResizeMenu(viewModel: viewModel)
+                    .disabled(isRecording)
+            }
+
+            if let status = viewModel.windowResizeStatus {
+                WindowResizeStatusRow(status: status) {
+                    viewModel.openAccessibilitySettings()
+                }
+            }
+
             // Preview thumbnail
             if viewModel.hasContentSelected {
                 PreviewThumbnailView(
@@ -145,6 +156,133 @@ struct MenuBarView: View {
         }
         .frame(width: 320)
         .background(.ultraThinMaterial)
+    }
+}
+
+// MARK: - Window Resize Menu
+
+struct WindowResizeMenu: View {
+    let viewModel: RecorderViewModel
+    @State private var isExpanded = false
+    @State private var isHovered = false
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Button {
+                withAnimation(.easeInOut(duration: 0.2)) {
+                    isExpanded.toggle()
+                }
+            } label: {
+                HStack(spacing: 12) {
+                    ZStack {
+                        Circle()
+                            .fill(.gray.opacity(0.2))
+                            .frame(width: 24, height: 24)
+
+                        Image(systemName: "arrow.up.left.and.arrow.down.right")
+                            .font(.system(size: 12, weight: .medium))
+                            .foregroundStyle(.primary)
+                    }
+
+                    Text("Resize")
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundStyle(.primary)
+
+                    Spacer()
+
+                    if let sizeLabel = viewModel.selectedWindowSizeLabel {
+                        Text(sizeLabel)
+                            .font(.system(size: 13))
+                            .foregroundStyle(.secondary)
+                    }
+
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundStyle(.secondary)
+                        .rotationEffect(.degrees(isExpanded ? 90 : 0))
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 6)
+                .contentShape(.rect)
+            }
+            .buttonStyle(.plain)
+            .background(
+                RoundedRectangle(cornerRadius: 4)
+                    .fill(isHovered ? .gray.opacity(0.1) : .clear)
+                    .padding(.horizontal, 4)
+            )
+            .onHover { hovering in
+                isHovered = hovering
+            }
+
+            if isExpanded {
+                VStack(spacing: 0) {
+                    ForEach(WindowResizePreset.allCases) { preset in
+                        PickerOptionRow(
+                            label: preset.label,
+                            isSelected: false
+                        ) {
+                            withAnimation(.easeInOut(duration: 0.2)) {
+                                isExpanded = false
+                            }
+
+                            Task {
+                                await viewModel.resizeSelectedWindow(to: preset)
+                            }
+                        }
+                    }
+                }
+                .padding(.leading, 12)
+                .background(.quaternary.opacity(0.3))
+            }
+        }
+    }
+}
+
+struct WindowResizeStatusRow: View {
+    let status: RecorderViewModel.WindowResizeStatus
+    let onOpenAccessibilitySettings: () -> Void
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: systemImage)
+                .font(.system(size: 12))
+                .foregroundStyle(tint)
+
+            Text(status.message)
+                .font(.system(size: 12))
+                .foregroundStyle(.secondary)
+                .lineLimit(2)
+
+            Spacer()
+
+            if status.canOpenAccessibilitySettings {
+                Button("Open Settings", action: onOpenAccessibilitySettings)
+                    .font(.system(size: 12))
+                    .buttonStyle(.plain)
+                    .foregroundStyle(.blue)
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 4)
+    }
+
+    private var systemImage: String {
+        switch status {
+        case .success:
+            "checkmark.circle.fill"
+        case .failure, .accessibilityPermissionMissing:
+            "exclamationmark.triangle.fill"
+        }
+    }
+
+    private var tint: Color {
+        switch status {
+        case .success:
+            .green
+        case .failure, .accessibilityPermissionMissing:
+            .orange
+        }
     }
 }
 

--- a/BetterCapture/ViewModel/RecorderViewModel.swift
+++ b/BetterCapture/ViewModel/RecorderViewModel.swift
@@ -23,12 +23,34 @@ final class RecorderViewModel {
         case stopping
     }
 
+    enum WindowResizeStatus: Equatable {
+        case success(String)
+        case failure(String)
+        case accessibilityPermissionMissing(String)
+
+        var message: String {
+            switch self {
+            case .success(let message), .failure(let message), .accessibilityPermissionMissing(let message):
+                message
+            }
+        }
+
+        var canOpenAccessibilitySettings: Bool {
+            if case .accessibilityPermissionMissing = self {
+                return true
+            }
+
+            return false
+        }
+    }
+
     // MARK: - Published Properties
 
     private(set) var state: RecordingState = .idle
     private(set) var recordingDuration: TimeInterval = 0
     private(set) var lastError: Error?
     private(set) var selectedContentFilter: SCContentFilter?
+    private(set) var windowResizeStatus: WindowResizeStatus?
 
     /// The source rectangle for area selection (in display points, top-left origin)
     private(set) var selectedSourceRect: CGRect?
@@ -56,6 +78,18 @@ final class RecorderViewModel {
         selectedContentFilter != nil
     }
 
+    var canResizeSelectedWindow: Bool {
+        selectedWindowForResize != nil && state == .idle
+    }
+
+    var selectedWindowSizeLabel: String? {
+        guard let window = selectedWindowForResize else { return nil }
+
+        let width = Int(window.frame.width.rounded())
+        let height = Int(window.frame.height.rounded())
+        return "\(width)x\(height)"
+    }
+
     var formattedDuration: String {
         let hours = Int(recordingDuration) / 3600
         let minutes = (Int(recordingDuration) % 3600) / 60
@@ -80,6 +114,7 @@ final class RecorderViewModel {
     let notificationService: NotificationService
     let permissionService: PermissionService
     private let captureEngine: CaptureEngine
+    private let windowResizeService: WindowResizeService
     private let assetWriter: AssetWriter
     private let cameraSession = CameraSession()
 
@@ -104,6 +139,7 @@ final class RecorderViewModel {
         self.notificationService = NotificationService(settings: settings)
         self.permissionService = PermissionService()
         self.captureEngine = CaptureEngine()
+        self.windowResizeService = WindowResizeService()
         self.assetWriter = AssetWriter()
 
         captureEngine.delegate = self
@@ -146,11 +182,14 @@ final class RecorderViewModel {
 
     /// Presents the system content sharing picker
     func presentPicker() {
+        windowResizeStatus = nil
         captureEngine.presentPicker()
     }
 
     /// Presents the area selection overlay on the display under the cursor
     func presentAreaSelection() async {
+        windowResizeStatus = nil
+
         // Dismiss any existing border frame so it doesn't overlap the selection overlay
         selectionBorderFrame.dismiss()
 
@@ -335,10 +374,45 @@ final class RecorderViewModel {
         selectedScreenRect = nil
         selectedScreen = nil
         selectedContentFilter = nil
+        windowResizeStatus = nil
         selectionBorderFrame.dismiss()
         recordingOverlay.dismiss()
         await previewService.stopPreview()
         previewService.clearPreview()
+    }
+
+    /// Resizes the currently selected single-window capture target.
+    func resizeSelectedWindow(to preset: WindowResizePreset) async {
+        guard let window = selectedWindowForResize else {
+            windowResizeStatus = .failure("Select a single window before resizing.")
+            return
+        }
+
+        do {
+            windowResizeStatus = nil
+            lastError = nil
+
+            _ = try windowResizeService.resize(window, to: preset)
+            await refreshSelectedWindowFilterIfAvailable(windowID: window.windowID)
+
+            windowResizeStatus = .success("Resized to \(preset.label)")
+            logger.info("Resized selected window to \(preset.label)")
+        } catch {
+            lastError = error
+            if let resizeError = error as? WindowResizeError,
+               case .accessibilityPermissionMissing = resizeError {
+                windowResizeStatus = .accessibilityPermissionMissing(error.localizedDescription)
+            } else {
+                windowResizeStatus = .failure(error.localizedDescription)
+            }
+            logger.error("Failed to resize selected window: \(error.localizedDescription)")
+        }
+    }
+
+    func openAccessibilitySettings() {
+        if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility") {
+            NSWorkspace.shared.open(url)
+        }
     }
 
     /// Starts the live preview stream (call when menu bar window opens)
@@ -373,6 +447,42 @@ final class RecorderViewModel {
     }
 
     // MARK: - Helper Methods
+
+    private var selectedWindowForResize: SCWindow? {
+        guard !isAreaSelection,
+              let windows = selectedContentFilter?.includedWindows,
+              windows.count == 1 else {
+            return nil
+        }
+
+        return windows[0]
+    }
+
+    private func currentWindow(windowID: CGWindowID) async throws -> SCWindow {
+        let content = try await SCShareableContent.current
+
+        guard let window = content.windows.first(where: { $0.windowID == windowID }) else {
+            throw WindowResizeError.windowUnavailable
+        }
+
+        return window
+    }
+
+    private func refreshSelectedWindowFilter(windowID: CGWindowID) async throws {
+        let window = try await currentWindow(windowID: windowID)
+        let filter = SCContentFilter(desktopIndependentWindow: window)
+        selectedContentFilter = filter
+        try await captureEngine.updateFilter(filter)
+        await previewService.setContentFilter(filter)
+    }
+
+    private func refreshSelectedWindowFilterIfAvailable(windowID: CGWindowID) async {
+        do {
+            try await refreshSelectedWindowFilter(windowID: windowID)
+        } catch {
+            logger.warning("Could not refresh resized window filter: \(error.localizedDescription)")
+        }
+    }
 
     private func getContentSize(from filter: SCContentFilter) async -> CGSize {
         // Apply scale if Capture Native Resolution setting is enabled
@@ -420,6 +530,7 @@ extension RecorderViewModel: CaptureEngineDelegate {
         selectedSourceRect = nil
         selectedScreenRect = nil
         selectedScreen = nil
+        windowResizeStatus = nil
         selectionBorderFrame.dismiss()
 
         selectedContentFilter = filter
@@ -472,6 +583,7 @@ extension RecorderViewModel: CaptureEngineDelegate {
 
         // Clear the selected content filter
         selectedContentFilter = nil
+        windowResizeStatus = nil
 
         // Dismiss the overlay if it was shown after a previous selection
         recordingOverlay.dismiss()
@@ -493,6 +605,7 @@ extension RecorderViewModel: PreviewServiceDelegate {
 
         // Clear the selection
         selectedContentFilter = nil
+        windowResizeStatus = nil
 
         // Clear the content filter in capture engine and deactivate picker
         captureEngine.clearSelection()

--- a/BetterCaptureTests/WindowResizePresetTests.swift
+++ b/BetterCaptureTests/WindowResizePresetTests.swift
@@ -1,0 +1,69 @@
+//
+//  WindowResizePresetTests.swift
+//  BetterCaptureTests
+//
+//  Created by Karel Busta on 13.05.26.
+//
+
+import CoreGraphics
+import Testing
+@testable import BetterCapture
+
+@MainActor
+struct WindowResizePresetTests {
+
+    @Test func includesRequiredPresets() {
+        let labels = WindowResizePreset.allCases.map(\.label)
+
+        #expect(labels == [
+            "9:16 720x1280",
+            "9:16 1080x1920",
+            "16:9 1280x720",
+            "16:9 1920x1080",
+            "1:1 1080x1080"
+        ])
+    }
+
+    @Test func targetFrameUsesPresetSizeWhenItFits() {
+        let frame = WindowResizeLayout.targetFrame(
+            for: .landscape720,
+            currentFrame: CGRect(x: 900, y: 700, width: 200, height: 200),
+            visibleFrame: CGRect(x: 0, y: 0, width: 2_200, height: 1_800),
+            margin: 0
+        )
+
+        #expect(frame == CGRect(x: 360, y: 440, width: 1_280, height: 720))
+    }
+
+    @Test func targetFrameClampsToVisibleFrame() {
+        let frame = WindowResizeLayout.targetFrame(
+            for: .landscape720,
+            currentFrame: CGRect(x: 1_900, y: 400, width: 100, height: 100),
+            visibleFrame: CGRect(x: 0, y: 0, width: 2_000, height: 1_200),
+            margin: 0
+        )
+
+        #expect(frame == CGRect(x: 720, y: 90, width: 1_280, height: 720))
+    }
+
+    @Test func targetFrameScalesDownLargePreset() {
+        let frame = WindowResizeLayout.targetFrame(
+            for: .landscape1080,
+            currentFrame: CGRect(x: 450, y: 300, width: 100, height: 100),
+            visibleFrame: CGRect(x: 0, y: 0, width: 1_000, height: 700),
+            margin: 0
+        )
+
+        #expect(frame == CGRect(x: 0, y: 69, width: 1_000, height: 562))
+    }
+
+    @Test func targetFrameHonorsMargin() {
+        let frame = WindowResizeLayout.targetFrame(
+            for: .landscape720,
+            currentFrame: CGRect(x: 600, y: 350, width: 200, height: 200),
+            visibleFrame: CGRect(x: 0, y: 0, width: 1_400, height: 900)
+        )
+
+        #expect(frame == CGRect(x: 60, y: 90, width: 1_280, height: 720))
+    }
+}


### PR DESCRIPTION
## Summary
- add common window resize presets for selected single-window recordings
- resize the target app window through macOS Accessibility APIs
- show clear menu-bar status for missing Accessibility permission or resize failures
- add focused tests for preset frame calculation and visible-frame clamping

## Testing
- `xcodebuild test -project BetterCapture.xcodeproj -scheme BetterCapture -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO`

## Notes
- Opened as draft because `CONTRIBUTING.md` asks for feature discussions before ready PR review.
