### PR TITLE
Add bettercapture:// URL scheme for external automation

### DIFF
--- a/BetterCapture/BetterCaptureApp.swift
+++ b/BetterCapture/BetterCaptureApp.swift
@@ -5,6 +5,7 @@
 //  Created by Joshua Sattler on 29.01.26.
 //
 
+import AppKit
 import KeyboardShortcuts
 import SwiftUI
 
@@ -21,6 +22,9 @@ struct BetterCaptureApp: App {
                     await viewModel.requestPermissionsOnLaunch()
                     registerKeyboardShortcuts()
                 }
+                .onOpenURL { url in
+                    handleURL(url)
+                }
         } label: {
             MenuBarLabel(viewModel: viewModel)
         }
@@ -29,6 +33,32 @@ struct BetterCaptureApp: App {
         // Settings window
         Settings {
             SettingsView(settings: viewModel.settings, updaterService: updaterService)
+        }
+    }
+
+    // MARK: - URL Scheme
+
+    private func handleURL(_ url: URL) {
+        guard url.scheme == "bettercapture" else { return }
+
+        switch url.host {
+        case "toggle":
+            Task { @MainActor in
+                await viewModel.toggleRecording()
+            }
+        case "open-recordings":
+            Task { @MainActor in
+                let settings = viewModel.settings
+                let didStart = settings.startAccessingOutputDirectory()
+                defer {
+                    if didStart {
+                        settings.stopAccessingOutputDirectory()
+                    }
+                }
+                NSWorkspace.shared.selectFile(nil, inFileViewerRootedAtPath: settings.outputDirectory.path)
+            }
+        default:
+            break
         }
     }
 

--- a/BetterCapture/BetterCaptureApp.swift
+++ b/BetterCapture/BetterCaptureApp.swift
@@ -44,7 +44,16 @@ struct BetterCaptureApp: App {
         switch url.host {
         case "toggle":
             Task { @MainActor in
-                await viewModel.toggleRecording()
+                if viewModel.isRecording {
+                    await viewModel.stopRecording()
+                } else {
+                    switch ContentSelectionMode.current {
+                    case .pickContent:
+                        viewModel.presentPicker()
+                    case .selectArea:
+                        await viewModel.presentAreaSelection()
+                    }
+                }
             }
         case "open-recordings":
             Task { @MainActor in

--- a/BetterCapture/Info.plist
+++ b/BetterCapture/Info.plist
@@ -16,5 +16,16 @@
 	<string>SPARKLE_PUBLIC_KEY</string>
 	<key>SUEnableInstallerLauncherService</key>
 	<true/>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>com.sattlerjoshua.BetterCapture</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>bettercapture</string>
+			</array>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/README.md
+++ b/README.md
@@ -46,6 +46,21 @@ Download the latest release from [GitHub Releases](https://github.com/jsattler/B
 
 **Requirements**: macOS 15.2 (Sequoia) or later
 
+## Automation
+
+BetterCapture supports a custom URL scheme for external tools (Raycast, Shortcuts, Alfred):
+
+| URL | Action |
+|---|---|
+| `bettercapture://toggle` | Toggle recording (same as the Toggle Recording shortcut) |
+| `bettercapture://open-recordings` | Open the output folder in Finder |
+
+Example:
+
+```bash
+open "bettercapture://toggle"
+```
+
 ## Contributing
 
 We welcome contributions of all kinds! Please see our [Contributing Guidelines](CONTRIBUTING.md) for more details on how to get involved.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ BetterCapture supports a custom URL scheme for external tools (Raycast, Shortcut
 
 | URL | Action |
 |---|---|
-| `bettercapture://toggle` | Toggle recording (same as the Toggle Recording shortcut) |
+| `bettercapture://toggle` | Stop recording if active; otherwise open content selection (Pick Content or Select Area) before recording |
 | `bettercapture://open-recordings` | Open the output folder in Finder |
 
 Example:


### PR DESCRIPTION
## Summary

- Register `bettercapture` URL scheme in `Info.plist`
- Handle `bettercapture://toggle` and `bettercapture://open-recordings` in `BetterCaptureApp.swift`
- Document supported URLs in README

## Motivation

External tools (Raycast, Shortcuts, Alfred) currently have no way to control BetterCapture except relaying configured keyboard shortcuts via Accessibility APIs. A URL scheme enables reliable automation without extra permissions.

Related discussion: https://github.com/jsattler/BetterCapture/discussions/169

## Supported URLs

| URL | Action |
|---|---|
| `bettercapture://toggle` | Calls `toggleRecording()` (same as Toggle Recording shortcut) |
| `bettercapture://open-recordings` | Opens output folder in Finder (same as menu bar action) |

## Test plan

- [ ] `open "bettercapture://toggle"` starts/stops recording
- [ ] `open "bettercapture://open-recordings"` opens output folder (including custom directory)
- [ ] URLs work when app was previously quit (macOS launches handler)

Made with [Cursor](https://cursor.com)