### PR TITLE
feat(automation): add toggle-copy URL scheme

### DIFF
--- a/BetterCapture/BetterCaptureApp.swift
+++ b/BetterCapture/BetterCaptureApp.swift
@@ -42,10 +42,11 @@ struct BetterCaptureApp: App {
         guard url.scheme == "bettercapture" else { return }
 
         switch url.host {
-        case "toggle":
+        case "toggle", "toggle-copy":
+            let copyToClipboard = url.host == "toggle-copy"
             Task { @MainActor in
                 if viewModel.isRecording {
-                    await viewModel.stopRecording()
+                    await viewModel.stopRecording(copyToClipboard: copyToClipboard)
                 } else {
                     switch ContentSelectionMode.current {
                     case .pickContent:

--- a/BetterCapture/ViewModel/RecorderViewModel.swift
+++ b/BetterCapture/ViewModel/RecorderViewModel.swift
@@ -290,7 +290,7 @@ final class RecorderViewModel {
     }
 
     /// Stops the current recording session
-    func stopRecording() async {
+    func stopRecording(copyToClipboard: Bool = false) async {
         guard isRecording else { return }
 
         state = .stopping
@@ -316,6 +316,10 @@ final class RecorderViewModel {
 
             // Send notification
             notificationService.sendRecordingSavedNotification(fileURL: outputURL)
+
+            if copyToClipboard {
+                copyFileToClipboard(outputURL)
+            }
 
             settings.stopAccessingOutputDirectory()
 
@@ -373,6 +377,12 @@ final class RecorderViewModel {
     }
 
     // MARK: - Helper Methods
+
+    private func copyFileToClipboard(_ url: URL) {
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.writeObjects([url as NSURL])
+    }
 
     private func getContentSize(from filter: SCContentFilter) async -> CGSize {
         // Apply scale if Capture Native Resolution setting is enabled

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ BetterCapture supports a custom URL scheme for external tools (Raycast, Shortcut
 | URL | Action |
 |---|---|
 | `bettercapture://toggle` | Stop recording if active; otherwise open content selection (Pick Content or Select Area) before recording |
+| `bettercapture://toggle-copy` | Same as `toggle`, but copies the saved recording to the clipboard when stopping |
 | `bettercapture://open-recordings` | Open the output folder in Finder |
 
 Example:


### PR DESCRIPTION
## Summary
- Add `bettercapture://toggle-copy` automation URL that mirrors `bettercapture://toggle` for starting recordings
- When stopping via this URL, copy the saved recording file to the clipboard
- Document the new URL in the README

## Test plan
- [ ] Run `open "bettercapture://toggle-copy"` while idle and confirm content selection opens
- [ ] Start a recording, then run `open "bettercapture://toggle-copy"` and confirm recording stops
- [ ] Paste from clipboard and confirm the saved recording file is available (e.g. in Finder or another app)


Made with [Cursor](https://cursor.com)