### PR TITLE
fix(settings): persist auto update check toggle

### DIFF
--- a/BetterCapture/Service/UpdaterService.swift
+++ b/BetterCapture/Service/UpdaterService.swift
@@ -36,8 +36,15 @@ final class UpdaterService {
     /// Whether Sparkle should automatically check for updates.
     /// This directly reads/writes Sparkle's own user-defaults-backed property.
     var automaticallyChecksForUpdates: Bool {
-        get { updater.automaticallyChecksForUpdates }
-        set { updater.automaticallyChecksForUpdates = newValue }
+        get {
+            access(keyPath: \.automaticallyChecksForUpdates)
+            return updater.automaticallyChecksForUpdates
+        }
+        set {
+            withMutation(keyPath: \.automaticallyChecksForUpdates) {
+                updater.automaticallyChecksForUpdates = newValue
+            }
+        }
     }
 
     // MARK: - Initialization
@@ -51,8 +58,6 @@ final class UpdaterService {
             updaterDelegate: nil,
             userDriverDelegate: nil
         )
-
-        guard hasValidKey else { return }
 
         // Observe Sparkle's canCheckForUpdates via KVO
         canCheckObservation = updater.observe(

--- a/BetterCapture/View/SettingsView.swift
+++ b/BetterCapture/View/SettingsView.swift
@@ -212,15 +212,7 @@ struct AudioSettingsView: View {
 
 struct GeneralSettingsView: View {
     @Bindable var settings: SettingsStore
-    var updaterService: UpdaterService
-
-    @State private var automaticallyChecksForUpdates: Bool
-
-    init(settings: SettingsStore, updaterService: UpdaterService) {
-        self.settings = settings
-        self.updaterService = updaterService
-        self._automaticallyChecksForUpdates = State(initialValue: updaterService.automaticallyChecksForUpdates)
-    }
+    @Bindable var updaterService: UpdaterService
 
     /// Formats the output directory path for display
     private var displayPath: String {
@@ -260,10 +252,7 @@ struct GeneralSettingsView: View {
             }
 
             Section("Software Updates") {
-                Toggle("Automatically check for updates", isOn: $automaticallyChecksForUpdates)
-                    .onChange(of: automaticallyChecksForUpdates) { _, newValue in
-                        updaterService.automaticallyChecksForUpdates = newValue
-                    }
+                Toggle("Automatically check for updates", isOn: $updaterService.automaticallyChecksForUpdates)
 
                 LabeledContent("Updates") {
                     Button("Check for Update") {


### PR DESCRIPTION
The toggle was bound to a private @State mirror seeded once in GeneralSettingsView.init, which SwiftUI re-seeded from a stale value when the Settings tab was switched away and back.

Fixes #192