### PR TITLE
fix(shortcuts): register global shortcuts at launch

### DIFF
--- a/BetterCapture/AppDelegate.swift
+++ b/BetterCapture/AppDelegate.swift
@@ -6,14 +6,16 @@
 //
 
 import AppKit
+import KeyboardShortcuts
 import OSLog
 
-/// Owns the recorder and handles `bettercapture://` URLs.
+/// Owns the recorder, registers the global keyboard shortcuts, and handles
+/// `bettercapture://` URLs.
 ///
-/// URL handling cannot live on the `MenuBarExtra` scene. SwiftUI only routes external
+/// None of this can live on the `MenuBarExtra` scene. SwiftUI only routes external
 /// events such as URLs to window-presenting scenes, and the menu bar content is not built
-/// until the user first opens the popover, so `onOpenURL` there is never registered.
-/// `NSApplicationDelegate` receives the Apple Event from launch onwards, which is why the
+/// until the user first opens the popover, so neither `onOpenURL` nor a `.task` there ever
+/// runs at launch. `NSApplicationDelegate` is active from launch onwards, which is why the
 /// recorder is owned here: it has to be reachable without the popover ever being opened.
 @MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate {
@@ -22,10 +24,38 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "BetterCapture", category: "AppDelegate")
 
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        registerKeyboardShortcuts()
+    }
+
     func application(_ application: NSApplication, open urls: [URL]) {
         for url in urls where url.scheme == "bettercapture" {
             handle(url)
         }
+    }
+
+    // MARK: - Keyboard Shortcuts
+
+    private func registerKeyboardShortcuts() {
+        KeyboardShortcuts.onKeyUp(for: .toggleRecording) { [viewModel] in
+            Task { @MainActor in
+                await viewModel.toggleRecording()
+            }
+        }
+
+        KeyboardShortcuts.onKeyUp(for: .selectContent) { [viewModel] in
+            Task { @MainActor in
+                viewModel.presentPicker()
+            }
+        }
+
+        KeyboardShortcuts.onKeyUp(for: .selectArea) { [viewModel] in
+            Task { @MainActor in
+                await viewModel.presentAreaSelection()
+            }
+        }
+
+        logger.info("Registered global keyboard shortcuts")
     }
 
     // MARK: - URL Scheme

--- a/BetterCapture/BetterCaptureApp.swift
+++ b/BetterCapture/BetterCaptureApp.swift
@@ -6,7 +6,6 @@
 //
 
 import AppKit
-import KeyboardShortcuts
 import SwiftUI
 
 @main
@@ -25,7 +24,6 @@ struct BetterCaptureApp: App {
             MenuBarView(viewModel: viewModel)
                 .task {
                     await viewModel.requestPermissionsOnLaunch()
-                    registerKeyboardShortcuts()
                 }
         } label: {
             MenuBarLabel(viewModel: viewModel)
@@ -35,28 +33,6 @@ struct BetterCaptureApp: App {
         // Settings window
         Settings {
             SettingsView(settings: viewModel.settings, updaterService: updaterService)
-        }
-    }
-
-    // MARK: - Keyboard Shortcuts
-
-    private func registerKeyboardShortcuts() {
-        KeyboardShortcuts.onKeyUp(for: .toggleRecording) { [viewModel] in
-            Task { @MainActor in
-                await viewModel.toggleRecording()
-            }
-        }
-
-        KeyboardShortcuts.onKeyUp(for: .selectContent) { [viewModel] in
-            Task { @MainActor in
-                viewModel.presentPicker()
-            }
-        }
-
-        KeyboardShortcuts.onKeyUp(for: .selectArea) { [viewModel] in
-            Task { @MainActor in
-                await viewModel.presentAreaSelection()
-            }
         }
     }
 }


### PR DESCRIPTION
MenuBarExtra content with .menuBarExtraStyle(.window) is built lazily, so the .task registering KeyboardShortcuts handlers never ran until the user first opened the popover. Move registration into AppDelegate.applicationDidFinishLaunching.

Fixes #199