### PR TITLE
chore(deps): update Sparkle to 2.9.6

### DIFF
--- a/BetterCapture.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/BetterCapture.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sparkle-project/Sparkle",
       "state" : {
-        "revision" : "21d8df80440b1ca3b65fa82e40782f1e5a9e6ba2",
-        "version" : "2.9.0"
+        "revision" : "ac2def288cbff5cfc7df3ffef6abdf45b72bcb0a",
+        "version" : "2.9.6"
       }
     }
   ],


### PR DESCRIPTION
Updates Sparkle from 2.9.0 to 2.9.6.

## Why

2.9.6 rolls up four security fixes reported against the 2.9 line:

- **2.9.2** — guard against symlinks when applying delta update files; enforce that the connection to the installer is validated before receiving appcast item data
- **2.9.5** — harden delta patching against a symlink at the destination path
- **2.9.6** — harden the installer moving the download archive, don't copy the progress tool for the root user (privilege escalation), reject package-based installs when signature validation failed

Details: https://github.com/sparkle-project/Sparkle/discussions/2838

Also picks up non-security fixes: a race-condition crash in `clearDownloadedUpdate` (2.9.1), an installation failure for bundle IDs ending in `.app` (2.9.3), and a window-activation fix for dockless/backgrounded apps (2.9.4) — the last one is relevant here since BetterCapture is a menu bar app.

## Changes

Only `Package.resolved`. The existing `upToNextMajorVersion(2.7.0)` requirement in the project already permits 2.9.6, so no `project.pbxproj` change is needed. No Sparkle API changes were required.

## Verification

- `xcodebuild build` — succeeded
- `xcodebuild test` — 144 tests in 11 suites passed
- `swiftlint lint` — no new warnings (14 pre-existing, unchanged from `main`)