### PR TITLE
chore(deps): update KeyboardShortcuts to 3.0.1

### DIFF
--- a/BetterCapture.xcodeproj/project.pbxproj
+++ b/BetterCapture.xcodeproj/project.pbxproj
@@ -514,7 +514,7 @@
 			repositoryURL = "https://github.com/sindresorhus/KeyboardShortcuts";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 2.4.0;
+				minimumVersion = 3.0.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/BetterCapture.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/BetterCapture.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sindresorhus/KeyboardShortcuts",
       "state" : {
-        "revision" : "1aef85578fdd4f9eaeeb8d53b7b4fc31bf08fe27",
-        "version" : "2.4.0"
+        "revision" : "49c3fc04ea827f816df67843bfcc57286b47ff06",
+        "version" : "3.0.1"
       }
     },
     {


### PR DESCRIPTION
Updates KeyboardShortcuts from 2.4.0 to 3.0.1 (major).

## Breaking changes in 3.0 — and why they don't affect us

Upstream made exactly two breaking changes:

- `Name#defaultShortcut` renamed to `Name#initialShortcut`
- the `Name` `default:` parameter renamed to `initial:`

This project uses neither. The full usage surface is:

- `BetterCapture/Model/KeyboardShortcutNames.swift:11-13` — plain `Self("...")`, no `default:` argument
- `BetterCapture/AppDelegate.swift:40,46,52` — `KeyboardShortcuts.onKeyUp(for:)`
- `BetterCapture/View/SettingsView.swift:45,49,50` — `KeyboardShortcuts.Recorder(_:name:)`

So this is a dependency-only change: no Swift source is modified.

## Also worth noting

3.0 fixes two things relevant to a menu bar app:

- `NSMenuItem#setShortcut(for:)` no longer overrides a hardcoded key equivalent when no global shortcut is set
- a false menu item conflict when reassigning an existing shortcut

3.0.1 fixes a release-build crash with the Swift 6.3 compiler. We're on Swift 6.2 so we weren't hit by it, but it removes a landmine for the next toolchain bump.

## Toolchain

3.0 ships as a `swift-tools-version:6.2` package and enables `defaultIsolation(MainActor.self)`, `NonisolatedNonsendingByDefault` and `InferIsolatedConformances` for its own target. It requires Xcode 26, which `.github/workflows/pull-request.yml` already pins (`XCODE_VERSION: '26.0'`). The app target itself still builds at `SWIFT_VERSION = 5.0`, and the new isolation defaults produced no diagnostics at our call sites.

## Verification

- `xcodebuild build -configuration Debug` — succeeded, no new warnings
- `xcodebuild build -configuration Release` — succeeded (checked explicitly given the 3.0.1 release-codegen fix)
- `xcodebuild test` — 144 tests in 11 suites passed
- `swiftlint lint` — 14 warnings, identical to `main`

Recording and triggering the three global shortcuts should still get a manual smoke test before merge.